### PR TITLE
Add return type to sendEmail and sendSms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.2.1] - 2020-05-29
+
+### Changed
+
+- Add Promise return type to sendSms and sendEmail
+
 ## [5.2.0] - 2020-04-14
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@govau-platforms/notify-client",
-  "version": "5.0.3",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govau-platforms/notify-client",
   "author": "Digital Transformation Agency",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "homepage": "https://github.com/govau/notify-client-node",
   "description": "Notify.gov.au Node.js client ",
   "license": "MIT",

--- a/spec/client.ts
+++ b/spec/client.ts
@@ -60,6 +60,7 @@ describe("notification api", () => {
         .sendEmail(templateId, email, options)
         .then(response => {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 
@@ -85,6 +86,7 @@ describe("notification api", () => {
         .sendEmail(templateId, email, options)
         .then(response => {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 
@@ -112,6 +114,7 @@ describe("notification api", () => {
         .sendEmail(templateId, email, options)
         .then(response => {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 
@@ -153,6 +156,7 @@ describe("notification api", () => {
         .sendSms(templateId, phoneNo, options)
         .then(function(response) {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 
@@ -178,6 +182,7 @@ describe("notification api", () => {
         .sendSms(templateId, phoneNo, options)
         .then(function(response) {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 
@@ -205,6 +210,7 @@ describe("notification api", () => {
         .sendSms(templateId, phoneNo, options)
         .then(function(response) {
           expect(response.statusCode).to.equal(200);
+          expect(response.body.hooray).to.equal("bkbbk");
         });
     });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,7 @@ export default class Client {
     templateId: string,
     emailAddress: string,
     options?: any
-  ): any {
+  ): Promise<any> {
     options = options || {};
     const err = checkOptionsKeys(
       [
@@ -38,7 +38,7 @@ export default class Client {
     const statusCallbackBearerToken =
       options.statusCallbackBearerToken || undefined;
 
-    return this.httpClient.post(
+    return Promise.resolve<RequestPromise>(this.httpClient.post(
       "/v2/notifications/email",
       createPayload(
         "email",
@@ -50,10 +50,10 @@ export default class Client {
         statusCallbackUrl,
         statusCallbackBearerToken
       )
-    );
+    ));
   }
 
-  public sendSms(templateId: string, phoneNumber: string, options?: any): any {
+  public sendSms(templateId: string, phoneNumber: string, options?: any): Promise<any> {
     options = options || {};
     const err = checkOptionsKeys(
       [
@@ -76,7 +76,7 @@ export default class Client {
     const statusCallbackBearerToken =
       options.statusCallbackBearerToken || undefined;
 
-    return this.httpClient.post(
+    return Promise.resolve<RequestPromise>(this.httpClient.post(
       "/v2/notifications/sms",
       createPayload(
         "sms",
@@ -88,7 +88,7 @@ export default class Client {
         statusCallbackUrl,
         statusCallbackBearerToken
       )
-    );
+    ));
   }
 
   public getNotificationById(notificationId: string): RequestPromise {


### PR DESCRIPTION
<!--Thanks for contributing to Notify.gov.au. Using this template to write your pull request message will help get it merged as soon as possible. -->

## What problem does the pull request solve?

Add return type to sendSms and sendEmail to make it clear that it returns a Promise.

## Checklist

<!--- All of the following are normally needed. Don’t worry if you haven’t done them or don’t know how – someone from the Notify team will be able to help. -->

- [x] I’ve used the pull request template
- [x] I’ve written unit tests for these changes
- [x] I’ve updated the documentation in
  - `README.md`
  - `CHANGELOG.md`
- [x] I’ve bumped the version number in
  - `package.json`
- [x] I've added new environment variables in
  - `CONTRIBUTING.md`
